### PR TITLE
feat: add Ollama model validation to onboarding wizard

### DIFF
--- a/workspace/cli/provider_steps.py
+++ b/workspace/cli/provider_steps.py
@@ -219,13 +219,21 @@ def validate_provider(provider: str, api_key: str) -> ValidationResult:
             os.environ[env_var] = old
 
 
-def validate_ollama(api_base: str = "http://localhost:11434") -> ValidationResult:
+def validate_ollama(
+    api_base: str = "http://localhost:11434", model: str | None = None
+) -> ValidationResult:
     """Validate Ollama availability via a synchronous httpx GET to /api/version.
 
     No litellm call is made — Ollama requires no API key.
 
+    If *model* is provided, also queries GET /api/tags to verify the model is
+    downloaded locally.  Ollama tag suffixes (e.g. ``:latest``) are ignored when
+    matching so ``"llama3.3"`` matches ``"llama3.3:latest"``.
+
     Returns:
-      ValidationResult(ok=True)  — HTTP 200
+      ValidationResult(ok=True)  — HTTP 200 (and model present if requested)
+      ValidationResult(ok=True,  error="model_not_found") — Ollama running but
+                                  model not downloaded; detail contains pull hint
       ValidationResult(ok=False, error="http_error")      — non-200 response
       ValidationResult(ok=False, error="not_running")     — connection refused
       ValidationResult(ok=False, error="timeout")         — 5 s timeout exceeded
@@ -234,6 +242,30 @@ def validate_ollama(api_base: str = "http://localhost:11434") -> ValidationResul
         resp = httpx.get(f"{api_base}/api/version", timeout=5.0)
         if resp.status_code == 200:
             version = resp.json().get("version", "unknown")
+
+            if model is not None:
+                try:
+                    tags_resp = httpx.get(f"{api_base}/api/tags", timeout=5.0)
+                    if tags_resp.status_code == 200:
+                        models_data = tags_resp.json().get("models", [])
+                        model_names = [m.get("name", "") for m in models_data]
+                        model_base = model.split(":")[0]
+                        found = any(
+                            name == model or name.startswith(f"{model_base}:")
+                            for name in model_names
+                        )
+                        if not found:
+                            return ValidationResult(
+                                ok=True,
+                                error="model_not_found",
+                                detail=(
+                                    f"Model '{model}' not found locally. "
+                                    f"Run: ollama pull {model}"
+                                ),
+                            )
+                except (httpx.ConnectError, httpx.TimeoutException):
+                    pass  # /api/tags unreachable — skip model check, Ollama is up
+
             return ValidationResult(ok=True, detail=f"Ollama {version} running")
         return ValidationResult(
             ok=False,

--- a/workspace/tests/test_onboard.py
+++ b/workspace/tests/test_onboard.py
@@ -814,3 +814,58 @@ def test_ensure_agent_workspace_legacy_git_dir_sets_completed_at(tmp_path):
     assert not (workspace / "BOOTSTRAP.md").exists(), (
         "BOOTSTRAP.md must NOT be created for a legacy (.git) workspace"
     )
+
+
+# ===========================================================================
+# ONB-16: Ollama model validation
+# ===========================================================================
+
+
+def test_validate_ollama_model_not_found():
+    """ONB-16: validate_ollama returns model_not_found when requested model is not downloaded."""
+    from cli.provider_steps import validate_ollama
+
+    version_resp = MagicMock()
+    version_resp.status_code = 200
+    version_resp.json.return_value = {"version": "0.5.0"}
+
+    tags_resp = MagicMock()
+    tags_resp.status_code = 200
+    tags_resp.json.return_value = {
+        "models": [
+            {"name": "mistral:latest"},
+            {"name": "phi3:mini"},
+        ]
+    }
+
+    with patch("httpx.get", side_effect=[version_resp, tags_resp]):
+        result = validate_ollama(model="llama3.3")
+
+    assert result.ok is True, "Ollama is reachable — ok should still be True"
+    assert result.error == "model_not_found", f"Expected model_not_found, got: {result.error}"
+    assert "llama3.3" in (result.detail or ""), "detail must mention the missing model name"
+    assert "ollama pull llama3.3" in (result.detail or ""), "detail must include pull command"
+
+
+def test_validate_ollama_model_found():
+    """ONB-16: validate_ollama returns ok=True with no error when model is present."""
+    from cli.provider_steps import validate_ollama
+
+    version_resp = MagicMock()
+    version_resp.status_code = 200
+    version_resp.json.return_value = {"version": "0.5.0"}
+
+    tags_resp = MagicMock()
+    tags_resp.status_code = 200
+    tags_resp.json.return_value = {
+        "models": [
+            {"name": "llama3.3:latest"},
+            {"name": "mistral:latest"},
+        ]
+    }
+
+    with patch("httpx.get", side_effect=[version_resp, tags_resp]):
+        result = validate_ollama(model="llama3.3")
+
+    assert result.ok is True
+    assert result.error != "model_not_found", "Model is present — must not return model_not_found"


### PR DESCRIPTION
After the reachability check passes, validate_ollama() now queries GET /api/tags to verify the requested model is downloaded locally. If the model is missing, ValidationResult returns ok=True with error='model_not_found' and a helpful 'ollama pull <model>' hint.

Two new tests cover the model-not-found and model-found paths (ONB-16).

## Summary

<!-- What does this PR do? 1-3 bullet points. -->

-
-

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] Tests only
- [ ] Other:

## Related Issue

Closes #<!-- issue number -->

## Testing

<!-- How did you test this? Check all that apply. -->

- [ ] Ran `pytest tests/ -v -m "not performance"` — all passing
- [ ] Added new tests covering this change
- [ ] Ran `ruff check workspace/` and `black workspace/ --check` — clean
- [ ] Tested manually (describe below)

## Notes for Reviewer

<!-- Anything specific you'd like the reviewer to focus on? -->
