### PR TITLE
fix(daemon): guard loginctl enable-linger against missing systemd on …

### DIFF
--- a/workspace/cli/daemon.py
+++ b/workspace/cli/daemon.py
@@ -264,12 +264,18 @@ class SystemdUserService(GatewayService):
         self._unit_path.parent.mkdir(parents=True, exist_ok=True)
         self._unit_path.write_text(self._build_unit(opts), encoding="utf-8")
 
-        # Enable linger so the user unit survives logout
-        subprocess.run(
-            ["loginctl", "enable-linger", str(os.getuid())],
-            check=False,
-            capture_output=True,
-        )
+        # Enable linger so the user unit survives logout (nice-to-have; skip if unavailable)
+        try:
+            subprocess.run(
+                ["loginctl", "enable-linger", str(os.getuid())],
+                check=True,
+                capture_output=True,
+            )
+        except (FileNotFoundError, subprocess.CalledProcessError):
+            print(
+                "Warning: loginctl not available — linger not enabled. "
+                "The service may stop after logout on some systems."
+            )
 
         subprocess.run(
             ["systemctl", "--user", "daemon-reload"],


### PR DESCRIPTION
…Linux

Wrap the loginctl subprocess call in try/except (FileNotFoundError, subprocess.CalledProcessError) so that daemon install continues gracefully on minimal Linux environments (Ubuntu minimal, Fedora containers, distros without systemd-logind). Linger is a nice-to-have, not a hard requirement.

## Summary

<!-- What does this PR do? 1-3 bullet points. -->

-
-

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] Tests only
- [ ] Other:

## Related Issue

Closes #<!-- issue number -->

## Testing

<!-- How did you test this? Check all that apply. -->

- [ ] Ran `pytest tests/ -v -m "not performance"` — all passing
- [ ] Added new tests covering this change
- [ ] Ran `ruff check workspace/` and `black workspace/ --check` — clean
- [ ] Tested manually (describe below)

## Notes for Reviewer

<!-- Anything specific you'd like the reviewer to focus on? -->
