### PR TITLE
fix(datetime): replace deprecated datetime.utcnow() with timezone-awa…

### DIFF
--- a/workspace/cli/onboard.py
+++ b/workspace/cli/onboard.py
@@ -274,9 +274,9 @@ def _handle_reset(reset_scope: str, data_root: Path) -> None:
         )
         raise typer.Exit(1)
 
-    from datetime import datetime  # noqa: PLC0415
+    from datetime import datetime, timezone  # noqa: PLC0415
 
-    timestamp = datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     backup_dir = data_root / "backups" / timestamp
     backup_dir.mkdir(parents=True, exist_ok=True)
 

--- a/workspace/cli/workspace_seeding.py
+++ b/workspace/cli/workspace_seeding.py
@@ -20,7 +20,7 @@ import contextlib
 import json
 import os
 import tempfile
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 # ---------------------------------------------------------------------------
@@ -200,4 +200,4 @@ def ensure_agent_workspace(
 
 def _utcnow() -> str:
     """Return current UTC time as ISO 8601 string (no microseconds)."""
-    return datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")


### PR DESCRIPTION
…re equivalent

Replace all datetime.utcnow() calls with datetime.now(timezone.utc) in:
- workspace/cli/workspace_seeding.py (_utcnow helper)
- workspace/cli/onboard.py (_handle_reset backup timestamp)

Fixes #14

## Summary

<!-- What does this PR do? 1-3 bullet points. -->

-
-

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code quality
- [ ] Documentation
- [ ] Tests only
- [ ] Other:

## Related Issue

Closes #<!-- issue number -->

## Testing

<!-- How did you test this? Check all that apply. -->

- [ ] Ran `pytest tests/ -v -m "not performance"` — all passing
- [ ] Added new tests covering this change
- [ ] Ran `ruff check workspace/` and `black workspace/ --check` — clean
- [ ] Tested manually (describe below)

## Notes for Reviewer

<!-- Anything specific you'd like the reviewer to focus on? -->
