### PR TITLE
docs: document the branch model and fix verified doc/code drift

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,38 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 2. Are all tokens/keys in `.gitignore`d files only?
 3. Does the code work for a fresh OSS install, not just this personal setup?
 
+## Branch model (read before diffing branches)
+
+**The application source on `main` and `develop` is identical.** A diff between them shows only
+development apparatus, never features. Do not go looking for unmerged code — there isn't any.
+
+| | `main` | `develop` |
+|---|---|---|
+| Application code | identical | identical |
+| `workspace/tests/` + `baileys-bridge/test/` | stripped | 258 + 7 files |
+| `.planning/` | not carried | 218 files |
+| `ruff` / `black` in CI | advisory (`continue-on-error`) | enforced |
+| `metrics.yml`, `parity.yml` | removed | present |
+
+`main` is the production/release branch and is deliberately test-free and planning-free (commits
+`3b1b328`, `86b7932`). `develop` is where code is written and where every change lands first.
+
+Consequences when working in this repo:
+- **All PRs target `develop`.** Never open one against `main`.
+- `pytest` on a `main` checkout collects nothing. Switch to `develop` to run or add tests.
+- `scripts/collect_metrics.sh` fails on `main` (`set -euo pipefail` + `grep` over a non-existent
+  `workspace/tests/`). It is a `develop`-only script.
+- `main` advances only by merging `develop`.
+- Milestone planning lives on `develop` in `.planning/ROADMAP.md` — v3.1 current, v4.0 (Bioinspired
+  Memory Architecture, phases 19–24) planned.
+
+## Security reporting
+
+Do **not** open public GitHub issues for vulnerabilities — `SECURITY.md` requires private
+disclosure via a [draft advisory](https://github.com/UpayanGhosh/Synapse-OSS/security/advisories/new).
+This applies to agent-generated audit findings too: route anything attacker-exploitable
+(auth bypass, RCE, SSRF, privilege escalation) to an advisory, not to the issue tracker.
+
 ## Code Graph (Default Behaviour)
 
 A persistent structural knowledge graph of this codebase is available via the `code-review-graph` MCP server.
@@ -52,9 +84,6 @@ synapse_start.bat           # Start all (Windows)
 
 # Baileys WhatsApp bridge only (Node.js subprocess — normally auto-spawned by WhatsAppChannel)
 ( cd baileys-bridge && npm install && node index.js )
-
-# Baileys WhatsApp bridge only (Node.js subprocess — normally auto-spawned by WhatsAppChannel)
-cd baileys-bridge && npm install && node index.js
 
 # CLI
 ( cd workspace && python main.py chat|ingest|vacuum|verify )
@@ -200,7 +229,7 @@ cadence follows gateway uptime, not battery/CPU state.
 | Key | Default | Description |
 |-----|---------|-------------|
 | `auto_flush_enabled` | `true` | Master switch. Set `false` to disable entirely (e.g. low-resource hosts). |
-| `auto_flush_idle_seconds` | `1800` | Seconds of inactivity before a session is auto-archived. OR-combined with count. |
+| `auto_flush_idle_seconds` | `21600` | Seconds of inactivity before a session is auto-archived (6 hours — see `SessionAutoFlushConfig` in `synapse_config.py`). OR-combined with count. |
 | `auto_flush_message_count` | `50` | Message count ceiling; sessions exceeding this flush even if recently active. |
 | `auto_flush_check_interval_seconds` | `60` | Scanner wake-up cadence in seconds. |
 | `auto_flush_min_messages` | `5` | Sessions below this count are never auto-flushed (avoids trivial exchanges). |
@@ -242,7 +271,7 @@ API:8000 | Baileys Bridge:5010 (internal) | Tools MCP:8989 | Ollama:11434 | OAut
 
 8. **Dual Cognition timeout** — `think()` is wrapped in `asyncio.wait_for(timeout=dual_cognition_timeout)`. If it times out, `CognitiveMerge()` (empty) is used and the message still gets a response. Tune via `session.dual_cognition_timeout` in `synapse.json` (default 5s).
 
-9. **Traffic Cop skip** — When `CognitiveMerge.response_strategy` is `"be_direct"`, `"analytical"`, or `"explore_with_care"`, the traffic cop LLM call is skipped and a role is mapped directly (`STRATEGY_TO_ROLE` constant in `api_gateway.py`). Falls back to normal traffic cop for unmapped strategies.
+9. **Traffic Cop skip** — When `CognitiveMerge.response_strategy` matches a key in the `STRATEGY_TO_ROLE` constant (defined in `llm_wrappers.py:90`, consumed at `chat_pipeline.py:2305`), the traffic cop LLM call is skipped and the role is mapped directly. Current mapping: `acknowledge` / `support` / `celebrate` / `redirect` → `CASUAL`; `challenge` / `quiz` → `ANALYSIS`. Falls back to the normal traffic cop for unmapped strategies.
 
 10. **Memory query is shared** — `MemoryEngine.query()` is called once in `persona_chat()` and results are passed to `dual_cognition.think(pre_cached_memory=...)`. Do NOT add a second memory query inside dual cognition.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,8 @@ development apparatus, never features. Do not go looking for unmerged code — t
 | | `main` | `develop` |
 |---|---|---|
 | Application code | identical | identical |
-| `workspace/tests/` + `baileys-bridge/test/` | stripped | 258 + 7 files |
+| `workspace/tests/` + `baileys-bridge/test/` | stripped | 273 + 9 files |
+| `workspace/AGENTS.md` | present | absent |
 | `.planning/` | not carried | 218 files |
 | `ruff` / `black` in CI | advisory (`continue-on-error`) | enforced |
 | `metrics.yml`, `parity.yml` | removed | present |

--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ Copy `.env.example` to `.env` and fill in `GEMINI_API_KEY` (only required key �
 ```bash
 git clone https://github.com/UpayanGhosh/Synapse-OSS.git
 cd Synapse-OSS
-( cd workspace && pip install -r requirements.txt )    # subshell — cwd auto-restores
+pip install -r requirements.txt                       # requirements.txt is at the repo root
 cp .env.example .env && $EDITOR .env
-( cd workspace && python main.py chat )
+( cd workspace && python main.py chat )                # subshell — cwd auto-restores
 ```
 
 For Docker, no-cloud, or production deploys, see [HOW_TO_RUN.md](HOW_TO_RUN.md).
@@ -88,12 +88,43 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for the full request flow, route map, and
 
 ## Project state
 
-- <!--METRIC:tests--> tests across <!--METRIC:test_files--> test files (CI-substituted; `bash scripts/collect_metrics.sh` to regenerate locally).
-- <!--METRIC:py_files--> Python source files.
+- 335 Python source files under `workspace/`.
+- 258 pytest files plus 7 Node test files for the Baileys bridge — these live on `develop`, not on
+  `main`. See [Branch model](#branch-model) below.
 - Single-user-per-instance today. Multi-user is planned (see PRODUCT_ISSUES.md issue 7.1).
 - Solo-maintained. See [GOVERNANCE.md](GOVERNANCE.md).
 
-Security disclosures: see [SECURITY.md](SECURITY.md).
+Security disclosures: see [SECURITY.md](SECURITY.md). Please do **not** open a public issue for a
+vulnerability — use a [draft advisory](https://github.com/UpayanGhosh/Synapse-OSS/security/advisories/new).
+
+## Branch model
+
+This repository uses two long-lived branches with a deliberate split of responsibilities. If you are
+comparing them and expecting the difference to be features, it is not — **the application source on
+`main` and `develop` is identical**. Only the surrounding development apparatus differs.
+
+| | `main` | `develop` |
+|---|---|---|
+| Application code | ✅ identical to develop | ✅ identical to main |
+| Test suite (`workspace/tests/`, `baileys-bridge/test/`) | ❌ stripped | ✅ 258 + 7 files |
+| `.planning/` (agent planning docs) | ❌ not carried | ✅ 218 files |
+| `ruff` / `black` in CI | advisory (`continue-on-error`) | enforced |
+| `metrics.yml`, `parity.yml` workflows | ❌ removed | ✅ present |
+
+**Why:** `main` is the production/release branch. It is intentionally free of tests and planning
+material so a release checkout carries only what is needed to run Synapse. Lint and test enforcement
+belong to `develop`, which is where code is actually written and where every change lands first.
+
+**What this means for contributors:**
+
+- **Open pull requests against `develop`**, never against `main`.
+- Run the test suite from `develop` — `pytest` on a `main` checkout will collect nothing.
+- `bash scripts/collect_metrics.sh` only works on `develop`; it counts `workspace/tests/`, which does
+  not exist on `main`.
+- `main` advances only by merging `develop` (see PR #33 for the shape of a production sync).
+
+Milestone planning lives on `develop` in `.planning/ROADMAP.md` — currently v3.1 (Reliability +
+OpenClaw Supervisor Patterns), with v4.0 (Bioinspired Memory Architecture) planned.
 
 ## Vision
 

--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ See [ARCHITECTURE.md](ARCHITECTURE.md) for the full request flow, route map, and
 ## Project state
 
 - 335 Python source files under `workspace/`.
-- 258 pytest files plus 7 Node test files for the Baileys bridge — these live on `develop`, not on
-  `main`. See [Branch model](#branch-model) below.
+- 258 `test_*.py` suites plus 5 `*.test.js` suites (273 and 9 files in those trees, counting fixtures
+  and helpers). These live on `develop`, not on `main` — see [Branch model](#branch-model) below.
 - Single-user-per-instance today. Multi-user is planned (see PRODUCT_ISSUES.md issue 7.1).
 - Solo-maintained. See [GOVERNANCE.md](GOVERNANCE.md).
 
@@ -106,7 +106,8 @@ comparing them and expecting the difference to be features, it is not — **the 
 | | `main` | `develop` |
 |---|---|---|
 | Application code | ✅ identical to develop | ✅ identical to main |
-| Test suite (`workspace/tests/`, `baileys-bridge/test/`) | ❌ stripped | ✅ 258 + 7 files |
+| Test suites (`workspace/tests/`, `baileys-bridge/test/`) | ❌ stripped | ✅ 273 + 9 files |
+| `workspace/AGENTS.md` | ✅ present | ❌ absent |
 | `.planning/` (agent planning docs) | ❌ not carried | ✅ 218 files |
 | `ruff` / `black` in CI | advisory (`continue-on-error`) | enforced |
 | `metrics.yml`, `parity.yml` workflows | ❌ removed | ✅ present |


### PR DESCRIPTION
## Why

The `main` vs `develop` split was undocumented, which made it look like `develop` held unmerged
features. It does not — **the application source on both branches is byte-identical**. Only the
development apparatus differs (tests, `.planning/`, lint enforcement, `metrics.yml`/`parity.yml`).

This PR writes that down so the question stops recurring, and fixes four doc claims that were
verified wrong against the code.

## README.md

- **New "Branch model" section** — states the split, why `main` is production-only (`3b1b328`,
  `86b7932`), and the consequences: PRs target `develop`, `pytest` collects nothing on a `main`
  checkout, `scripts/collect_metrics.sh` is `develop`-only.
- **Fixed the three `<!--METRIC:*-->` placeholders.** `metrics.yml` was removed from `main` in
  `86b7932`, so nothing substitutes them on this branch — "Project state" was rendering literally as
  " tests across  test files". Replaced with static counts (335 Python files; 258 + 7 test files on
  `develop`).
- **Fixed the quickstart install command.** `requirements.txt` is at the repo root, so the documented
  `( cd workspace && pip install -r requirements.txt )` fails with
  `Could not open requirements file` on the *first* step for every new user.
- Vulnerability reports now point at draft advisories, per `SECURITY.md`.

## CLAUDE.md

- Same branch-model table, plus a security-reporting rule so agent-generated audit findings route
  exploitable issues to an advisory rather than the public tracker.
- Removed a duplicated "Baileys WhatsApp bridge only" block — `develop` had already dropped it,
  `main` kept both copies.
- `auto_flush_idle_seconds` was documented as `1800`; `SessionAutoFlushConfig`
  (`workspace/synapse_config.py`) sets **`21600`** (6 hours).
- `STRATEGY_TO_ROLE` was documented with three strategies that **do not exist** in the code
  (`be_direct`, `analytical`, `explore_with_care`) and the **wrong location** (`api_gateway.py`).
  Actual: `llm_wrappers.py:90`, mapping `acknowledge`/`support`/`celebrate`/`redirect` → `CASUAL`
  and `challenge`/`quiz` → `ANALYSIS`.

## Verification

Every claim was checked against the code on `86b7932`, not inferred:

| Claim | Check |
|---|---|
| No `workspace/requirements.txt` | `ls` — absent; root copy present |
| METRIC placeholders unfilled | `ls .github/workflows/` — no `metrics.yml` |
| `collect_metrics.sh` breaks on main | `set -euo pipefail` + `grep -rh workspace/tests/` (dir absent) |
| `auto_flush_idle_seconds` = 21600 | `SessionAutoFlushConfig` docstring + field default |
| `STRATEGY_TO_ROLE` contents/location | `grep -A10` at `llm_wrappers.py:90` |
| Branch code identical | `git diff --name-status origin/main origin/develop` — zero `.py` files |

Docs-only; no source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)