### PR TITLE
fix: persist vectors during re-embedding

### DIFF
--- a/workspace/sci_fi_dashboard/embedding/migrate.py
+++ b/workspace/sci_fi_dashboard/embedding/migrate.py
@@ -5,6 +5,7 @@ Invoked by: synapse re-embed [--dry-run] [--batch-size N] [--db PATH]
 Responsibilities:
 - Find all documents whose embedding_model differs from the active provider.
 - Re-embed them in configurable batch sizes.
+- Persist the vectors in sqlite-vec and LanceDB before marking them migrated.
 - Update provenance columns (embedding_model, embedding_version) on success.
 - Support --dry-run to preview the plan without touching data.
 """
@@ -13,11 +14,14 @@ from __future__ import annotations
 
 import logging
 import sqlite3
+import struct
+from contextlib import closing
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from sci_fi_dashboard.embedding.base import EmbeddingProvider
+    from sci_fi_dashboard.vector_store.base import VectorStore
 
 logger = logging.getLogger(__name__)
 
@@ -27,6 +31,7 @@ def re_embed_documents(
     provider: EmbeddingProvider,
     batch_size: int = 64,
     dry_run: bool = False,
+    vector_store: VectorStore | None = None,
 ) -> dict[str, int]:
     """
     Re-embed all documents that don't have embeddings from the current provider.
@@ -41,6 +46,8 @@ def re_embed_documents(
         batch_size: Number of documents to embed per round-trip to the model.
         dry_run:    When ``True``, count rows that need re-embedding but do not
                     write anything to the database.
+        vector_store: Optional vector store used for the re-embedded vectors.
+            When omitted, the default :class:`LanceDBVectorStore` is used.
 
     Returns:
         A dict with keys ``"processed"``, ``"skipped"``, and ``"errors"`` where
@@ -49,10 +56,11 @@ def re_embed_documents(
     stats: dict[str, int] = {"processed": 0, "skipped": 0, "errors": 0}
     provider_info = provider.info()
 
-    with sqlite3.connect(str(db_path)) as conn:
+    owns_vector_store = False
+    with closing(sqlite3.connect(str(db_path))) as conn:
         # Rows that need re-embedding: model mismatch or no model recorded yet.
         cursor = conn.execute(
-            "SELECT id, content FROM documents"
+            "SELECT id, content, hemisphere_tag, unix_timestamp, importance FROM documents"
             " WHERE embedding_model != ? OR embedding_model IS NULL",
             (provider_info.model,),
         )
@@ -63,35 +71,74 @@ def re_embed_documents(
             stats["processed"] = len(rows)
             return stats
 
-        for i in range(0, len(rows), batch_size):
-            batch = rows[i : i + batch_size]
-            ids = [r[0] for r in batch]
-            texts = [r[1] for r in batch]
+        try:
+            if vector_store is None:
+                from sci_fi_dashboard.vector_store import LanceDBVectorStore
 
-            try:
-                vectors = provider.embed_documents(texts)
-                for row_id, _vector in zip(ids, vectors, strict=False):
-                    # Update provenance metadata.
-                    # The actual embedding bytes are written by the ingestion
-                    # pipeline's vec_items upsert — this function only updates
-                    # the tracking columns so the row won't be re-processed
-                    # on the next run.
-                    conn.execute(
-                        "UPDATE documents"
-                        " SET embedding_model = ?, embedding_version = ?"
-                        " WHERE id = ?",
-                        (provider_info.model, f"{provider_info.name}-v1", row_id),
+                vector_store = LanceDBVectorStore()
+                owns_vector_store = True
+
+            for i in range(0, len(rows), batch_size):
+                batch = rows[i : i + batch_size]
+                texts = [r[1] for r in batch]
+
+                try:
+                    vectors = provider.embed_documents(texts)
+                    if len(vectors) != len(batch):
+                        raise ValueError(
+                            f"Embedding provider returned {len(vectors)} vectors for "
+                            f"{len(batch)} documents"
+                        )
+
+                    facts = []
+                    for row, vector in zip(batch, vectors, strict=True):
+                        row_id, content, hemisphere_tag, unix_timestamp, importance = row
+                        vec_blob = struct.pack(f"{len(vector)}f", *vector)
+                        conn.execute(
+                            "DELETE FROM vec_items WHERE document_id = ?",
+                            (row_id,),
+                        )
+                        conn.execute(
+                            "INSERT INTO vec_items(document_id, embedding) VALUES (?, ?)",
+                            (row_id, vec_blob),
+                        )
+                        conn.execute(
+                            "UPDATE documents"
+                            " SET embedding_model = ?, embedding_version = ?"
+                            " WHERE id = ?",
+                            (provider_info.model, f"{provider_info.name}-v1", row_id),
+                        )
+                        facts.append(
+                            {
+                                "id": row_id,
+                                "vector": vector,
+                                "metadata": {
+                                    "text": content,
+                                    "hemisphere_tag": hemisphere_tag or "safe",
+                                    "unix_timestamp": unix_timestamp or 0,
+                                    "importance": importance if importance is not None else 5,
+                                },
+                            }
+                        )
+
+                    vector_store.upsert_facts(facts)
+                    conn.commit()
+                    stats["processed"] += len(batch)
+                    logger.info(
+                        "[ReEmbed] Processed batch %d, %d total",
+                        i // batch_size + 1,
+                        stats["processed"],
                     )
-                    stats["processed"] += 1
-                conn.commit()
-                logger.info(
-                    "[ReEmbed] Processed batch %d, %d total",
-                    i // batch_size + 1,
-                    stats["processed"],
-                )
-            except Exception as exc:
-                logger.error("[ReEmbed] Batch error: %s", exc)
-                stats["errors"] += len(batch)
+                except Exception as exc:
+                    conn.rollback()
+                    logger.error("[ReEmbed] Batch error: %s", exc)
+                    stats["errors"] += len(batch)
+        except Exception as exc:
+            logger.error("[ReEmbed] Vector store initialization error: %s", exc)
+            stats["errors"] = len(rows)
+        finally:
+            if owns_vector_store and vector_store is not None:
+                vector_store.close()
 
     return stats
 

--- a/workspace/tests/test_embedding_migrate.py
+++ b/workspace/tests/test_embedding_migrate.py
@@ -1,0 +1,114 @@
+import sqlite3
+import struct
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from sci_fi_dashboard.embedding.migrate import re_embed_documents  # noqa: E402
+
+
+class StubProvider:
+    def info(self):
+        return SimpleNamespace(model="new-model", name="stub", dimensions=3)
+
+    def embed_documents(self, texts):
+        return [[9.0, 8.0, 7.0] for _ in texts]
+
+
+class RecordingVectorStore:
+    def __init__(self):
+        self.facts = []
+
+    def upsert_facts(self, facts):
+        self.facts.extend(facts)
+
+
+class FailingVectorStore:
+    def upsert_facts(self, facts):
+        raise RuntimeError("vector store unavailable")
+
+
+def make_database(path: Path) -> None:
+    with sqlite3.connect(path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE documents (
+                id INTEGER PRIMARY KEY,
+                content TEXT NOT NULL,
+                hemisphere_tag TEXT,
+                unix_timestamp INTEGER,
+                importance INTEGER,
+                embedding_model TEXT,
+                embedding_version TEXT
+            );
+            CREATE TABLE vec_items (
+                document_id INTEGER PRIMARY KEY,
+                embedding BLOB NOT NULL
+            );
+            INSERT INTO documents
+                VALUES (1, 'memory to re-embed', 'safe', 123, 7, 'old-model', 'old-v1');
+            """,
+        )
+        conn.execute(
+            "INSERT INTO vec_items VALUES (?, ?)",
+            (1, sqlite3.Binary(struct.pack("3f", 1.0, 2.0, 3.0))),
+        )
+
+
+def read_document(path: Path):
+    with sqlite3.connect(path) as conn:
+        document = conn.execute(
+            "SELECT embedding_model, embedding_version FROM documents WHERE id = 1"
+        ).fetchone()
+        vector = conn.execute("SELECT embedding FROM vec_items WHERE document_id = 1").fetchone()[0]
+    return document, struct.unpack("3f", vector)
+
+
+def test_re_embed_writes_sqlite_and_lancedb_vectors(tmp_path):
+    db_path = tmp_path / "memory.db"
+    make_database(db_path)
+    vector_store = RecordingVectorStore()
+
+    stats = re_embed_documents(db_path, StubProvider(), vector_store=vector_store)
+
+    assert stats == {"processed": 1, "skipped": 0, "errors": 0}
+    assert read_document(db_path) == (("new-model", "stub-v1"), (9.0, 8.0, 7.0))
+    assert vector_store.facts == [
+        {
+            "id": 1,
+            "vector": [9.0, 8.0, 7.0],
+            "metadata": {
+                "text": "memory to re-embed",
+                "hemisphere_tag": "safe",
+                "unix_timestamp": 123,
+                "importance": 7,
+            },
+        }
+    ]
+
+
+def test_re_embed_keeps_rows_retryable_when_vector_store_fails(tmp_path):
+    db_path = tmp_path / "memory.db"
+    make_database(db_path)
+
+    stats = re_embed_documents(db_path, StubProvider(), vector_store=FailingVectorStore())
+
+    assert stats == {"processed": 0, "skipped": 0, "errors": 1}
+    assert read_document(db_path) == (("old-model", "old-v1"), (1.0, 2.0, 3.0))
+
+
+def test_re_embed_dry_run_does_not_touch_vectors(tmp_path):
+    db_path = tmp_path / "memory.db"
+    make_database(db_path)
+
+    stats = re_embed_documents(
+        db_path,
+        StubProvider(),
+        dry_run=True,
+        vector_store=FailingVectorStore(),
+    )
+
+    assert stats == {"processed": 1, "skipped": 0, "errors": 0}
+    assert read_document(db_path) == (("old-model", "old-v1"), (1.0, 2.0, 3.0))


### PR DESCRIPTION
## Summary / Problem

`synapse re-embed` computed replacement embeddings but discarded every vector, then marked the documents as migrated. Existing sqlite-vec and LanceDB data therefore stayed stale, and the rows could not be selected for repair again.

## Changes

- Persist each replacement embedding to `vec_items`, replacing the prior vector for the document.
- Upsert the same embedding through the existing `LanceDBVectorStore` abstraction with the document metadata.
- Commit embedding provenance only after both vector writes succeed; roll back a failed batch so it remains retryable.
- Close the SQLite connection and validate that providers return one vector per input document.
- Add regression tests for successful dual-store persistence, failure rollback, and dry-run behavior.

## Tests

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest --basetemp=<isolated> workspace/tests -q` — 3 passed.
- `ruff check workspace/sci_fi_dashboard/embedding/migrate.py workspace/tests/test_embedding_migrate.py` — passed.
- `black --check workspace/sci_fi_dashboard/embedding/migrate.py workspace/tests/test_embedding_migrate.py` — passed.
- `pytest workspace` could not complete collection because the pre-existing `workspace/scripts/memory_test.py` opens the default database path, which is not writable in this Windows environment.

## Compatibility / Known limitations

No schema, public API, or dependency changes are introduced. The production path uses the existing `LanceDBVectorStore`; the regression tests inject a recording store so they remain deterministic without downloading the optional native LanceDB wheel locally.

## Issue link

Fixes #35
